### PR TITLE
Use `GH_REPO` instead of `--repo` option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,13 +24,14 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        GH_REPO: ${{ inputs.repo }}
       run: |
         # Delete pull request caches
-        for id in $(gh cache list --repo ${{ inputs.repo }} --ref refs/pull/${{ inputs.pr-number }}/merge --json id --jq '.[].id'); do
-          gh cache delete $id --repo ${{ inputs.repo }}
+        for id in $(gh cache list --ref refs/pull/${{ inputs.pr-number }}/merge --json id --jq '.[].id'); do
+          gh cache delete $id
         done
 
         # Delete branch caches
-        for id in $(gh cache list --repo ${{ inputs.repo }} --ref refs/heads/${{ inputs.head-ref }} --json id --jq '.[].id'); do
-          gh cache delete $id --repo ${{ inputs.repo }}
+        for id in $(gh cache list --ref refs/heads/${{ inputs.head-ref }} --json id --jq '.[].id'); do
+          gh cache delete $id
         done


### PR DESCRIPTION
> `GH_REPO`: specify the GitHub repository in the [HOST/]OWNER/REPO format for commands that otherwise operate on a local repository.

[GitHub CLI | Take GitHub to the command line](https://cli.github.com/manual/gh_help_environment)